### PR TITLE
Feature/temp recipe

### DIFF
--- a/components/IndividualRecipe.js
+++ b/components/IndividualRecipe.js
@@ -52,6 +52,7 @@ function IndividualRecipe(props) {
     console.log(userId);
     const [modal, setModal] = useState({ save: false, cancel: false });
     const recipe = useSelector(state => state.singleRecipe.recipe);
+    const [tempRecipe, setTempRecipe] = useState(null);
     console.log("recipe", recipe);
     const totalCookTime = (recipe.prep_time || 0) + (recipe.cook_time || 0);
     const isLoading = useSelector(state => state.singleRecipe.isLoading);
@@ -119,6 +120,7 @@ function IndividualRecipe(props) {
         if (!recipe.owner.user_id || userId !== recipe.owner.user_id)
             return dispatch(stopEditMode());
         dispatch(startEditMode());
+        setTempRecipe(recipe);
     };
 
     const saveButtonEditedRecipe = author_comment => {
@@ -143,7 +145,7 @@ function IndividualRecipe(props) {
                     onPress: () => {
                         dispatch(stopEditMode());
                         dispatch(resetCurrentActive());
-                        dispatch(fetchRecipe(id));
+                        dispatch(resetRecipe(tempRecipe));
                     },
                 },
             ],

--- a/store/singleRecipe/singleRecipeActions.js
+++ b/store/singleRecipe/singleRecipeActions.js
@@ -129,8 +129,9 @@ export const saveNewRecipe = recipeInfo => async dispatch => {
 };
 
 export const RESET_RECIPE = "RESET_RECIPE";
-export const resetRecipe = () => ({
+export const resetRecipe = (recipe = null) => ({
     type: RESET_RECIPE,
+    payload: recipe,
 });
 
 // currentActive indicates a recipe field that is currently swiped/open. It is set

--- a/store/singleRecipe/singleRecipeReducer.js
+++ b/store/singleRecipe/singleRecipeReducer.js
@@ -148,7 +148,10 @@ export const singleRecipeReducer = (state = initState, action) => {
                 ...state,
                 recipe: {
                     ...state.recipe,
-                    instructions: [...state.recipe.instructions, action.payload],
+                    instructions: [
+                        ...state.recipe.instructions,
+                        action.payload,
+                    ],
                 },
             };
 
@@ -226,7 +229,9 @@ export const singleRecipeReducer = (state = initState, action) => {
             };
 
         case RESET_RECIPE:
-            return initState;
+            return action.payload
+                ? { ...state, recipe: action.payload }
+                : initState;
 
         default:
             return state;


### PR DESCRIPTION
# Release Canvas 2 - Store recipe in tempRecipe 
This PR will avoid re-fetching the recipe from the backend when canceling edit mode

## Changelog
* Added an optional recipe parameter to the resetRecipe action
* RESET_RECIPE reducer now returns either initState if no recipe is passed by the action or the recipe
* Refactored to avoid fetching recipe from the backend if canceling edit mode
