### PR TITLE
Feature/input length restriction

### DIFF
--- a/components/EditRecipeComponents/Title.js
+++ b/components/EditRecipeComponents/Title.js
@@ -68,6 +68,7 @@ const Title = ({ title, currentActive }) => {
                         }}
                         style={styles.title}
                         multiline
+                        maxLength={23}
                         returnKeyType="done"
                         autoFocus={true}
                         enablesReturnKeyAutomatically={true}
@@ -79,9 +80,7 @@ const Title = ({ title, currentActive }) => {
                 </View>
             ) : (
                 <View style={styles.titleContainer}>
-                    <Text style={styles.title}>
-                        {title}
-                    </Text>
+                    <Text style={styles.title}>{title}</Text>
                     <MaterialCommunityIcons
                         name="drag-vertical"
                         size={32}

--- a/components/IndividualRecipe.js
+++ b/components/IndividualRecipe.js
@@ -71,7 +71,8 @@ function IndividualRecipe(props) {
 
     const loadRecipe = async () => {
         try {
-            if (!!Number(revisionId)) dispatch(fetchVersionByRevisionId(id, revisionId));
+            if (!!Number(revisionId))
+                dispatch(fetchVersionByRevisionId(id, revisionId));
             else dispatch(fetchRecipe(id));
         } catch (error) {
             throw new Error("This is an error");
@@ -140,8 +141,7 @@ function IndividualRecipe(props) {
     const hasRevisions = () =>
         // Double !! turn the value into a guaranteed boolean (true or false)
         // If any values are 'undefined' or 'NaN', this will ensure they are 'false'
-        !!Number(revisionId) ||
-        !!Number(recipe.previous_versions_count);
+        !!Number(revisionId) || !!Number(recipe.previous_versions_count);
 
     const getVersionString = () =>
         recipe.revision_number
@@ -172,7 +172,7 @@ function IndividualRecipe(props) {
         );
     };
 
-    if (!recipe.title || isLoading) {
+    if (isLoading) {
         return (
             <View
                 style={{
@@ -184,13 +184,6 @@ function IndividualRecipe(props) {
             >
                 <RecipeShareLogo />
                 <ActivityIndicator size="large" color="#444444" />
-            </View>
-        );
-    }
-    if (isLoading) {
-        return (
-            <View style={styles.centered}>
-                <ActivityIndicator size="large" color="#00ff00" />
             </View>
         );
     }

--- a/components/Ingredient.js
+++ b/components/Ingredient.js
@@ -123,13 +123,15 @@ const Ingredient = ({
                 <TextInput
                     ref={nameInput}
                     style={{
-                        height: 40,
+                        minHeight: 40,
                         width: "50%",
                         borderWidth: highlighted.name ? 1 : 0.8,
                         borderColor: highlighted.name ? "#FF0000" : "#363838",
                         borderRadius: 4,
                         textAlign: "center",
                     }}
+                    multiline
+                    maxLength={44}
                     placeholder="Ingredient Name"
                     onChangeText={event => handleChange("name", event)}
                     returnKeyType="done"
@@ -149,6 +151,7 @@ const Ingredient = ({
                         textAlign: "center",
                     }}
                     placeholder="Amount"
+                    maxLength={3}
                     keyboardType={"numeric"}
                     onChangeText={qty =>
                         handleChange(

--- a/components/RecipeName.js
+++ b/components/RecipeName.js
@@ -3,19 +3,22 @@ import { Text, TextInput } from "react-native";
 import styles from "../styles/createRecipeStyles";
 
 const RecipeName = ({ recipe, setRecipe }) => {
+    const maxLength = 23;
     return (
         <>
             <Text style={styles.heading}>Title</Text>
 
             <TextInput
                 style={styles.RecipeNameContainer}
-                maxLength={55}
+                maxLength={maxLength}
                 placeholder="Enter Title"
                 onChangeText={event => setRecipe({ ...recipe, title: event })}
                 value={recipe.title}
             />
 
-            <Text style={styles.fiftyFive}>{recipe.title.length}/55</Text>
+            <Text style={styles.fiftyFive}>
+                {`${recipe.title.length}/${maxLength}`}
+            </Text>
         </>
     );
 };


### PR DESCRIPTION
# Release Canvas 2 - Input Length Restriction
This PR will implement max length restriction to title, ingredient name and quantity. 

## Changelog
* Limited title field to 23 characters
* Fixed bug that recipe component to reload permanently when editing and backspacing the title completely
* Added maxlength and multiline to ingredient name, and maxlength to quantity
